### PR TITLE
cache-purge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	memcached \
+	nginx-mod-http-cache-purge \
 	nginx-mod-http-echo \
 	nginx-mod-http-fancyindex \
 	nginx-mod-http-geoip \


### PR DESCRIPTION
we got lucky someones already compile it for alpine ;)

but for sure it's more useful when you use nginx as a proxy so maybe linuxerver should propose a nginx-proxy image

- https://pkgs.alpinelinux.org/package/v3.7/main/x86_64/nginx-mod-http-cache-purge
- https://github.com/FRiCKLE/ngx_cache_purge