### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.9
+FROM lsiobase/nginx:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.9
+FROM lsiobase/nginx:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.9
+FROM lsiobase/nginx:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "08.05.19:", desc: "Remove default.conf when nginx is upgraded in downstream image." }
   - { date: "30.04.19:", desc: "Add php-redis." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.