### PR TITLE
Plugins: added support for the VTS pluggin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN \
     nginx-mod-http-set-misc==${NGINX_VERSION} \
     nginx-mod-http-upload-progress==${NGINX_VERSION} \
     nginx-mod-http-xslt-filter==${NGINX_VERSION} \
+    nginx-mod-http-vts==${NGINX_VERSION} \
     nginx-mod-mail==${NGINX_VERSION} \
     nginx-mod-rtmp==${NGINX_VERSION} \
     nginx-mod-stream==${NGINX_VERSION} \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -35,6 +35,7 @@ RUN \
     nginx-mod-http-set-misc==${NGINX_VERSION} \
     nginx-mod-http-upload-progress==${NGINX_VERSION} \
     nginx-mod-http-xslt-filter==${NGINX_VERSION} \
+    nginx-mod-http-vts==${NGINX_VERSION} \
     nginx-mod-mail==${NGINX_VERSION} \
     nginx-mod-rtmp==${NGINX_VERSION} \
     nginx-mod-stream==${NGINX_VERSION} \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -35,6 +35,7 @@ RUN \
     nginx-mod-http-set-misc==${NGINX_VERSION} \
     nginx-mod-http-upload-progress==${NGINX_VERSION} \
     nginx-mod-http-xslt-filter==${NGINX_VERSION} \
+    nginx-mod-http-vts==${NGINX_VERSION} \
     nginx-mod-mail==${NGINX_VERSION} \
     nginx-mod-rtmp==${NGINX_VERSION} \
     nginx-mod-stream==${NGINX_VERSION} \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "30.05.22:", desc: "Added support for VTS pluggin." }
   - { date: "22.05.22:", desc: "Install nginx version from 3.14." }
   - { date: "01.07.21:", desc: "Rebasing to alpine 3.14." }
   - { date: "24.06.21:", desc: "Update default nginx conf folder." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [v] I have read the [contributing](https://github.com/linuxserver/docker-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Added the VTS pluggin package in the dockerfiles.
The VTS pluggin allows to export way more infromation for monitoring purpose that can be digested and presented by other tools, such as Prometheus.
Although the pluggin is not fully supported by the maintener for recent versions of nginx, Alpine Linux seems to support it by providing packages for the currently used version of Nginx.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This VTS pluggin, when used by the end user, would allow to export a lot of data from the Nginx server and allow better monitoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I first updated the x86/amd64 Dockerfile, built it and ran it on my infrastructure (I use it as a reverse proxy for all my services behind).
I then configured it to export the data to Prometheus and checked the information there.

For the other architectures, I used the qemu-user-static tool to build and run it.
Here is the extract of the process:

```
❯ docker build -t docker-nginx:aarch64 --build-arg ARCH=arm64v8/ -f Dockerfile.aarch64 .
Sending build context to Docker daemon  117.8kB
Step 1/9 : FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.14
arm64v8-3.14: Pulling from linuxserver/baseimage-alpine-nginx
ce7df4a98b4b: Pull complete 
a15cdef601cf: Pull complete 
c9580a59a2cb: Pull complete 
18e003f62515: Pull complete 
96e24f72563a: Pull complete 
3b5a5a402516: Pull complete 
97c95d9845cc: Pull complete 
879aca0798b6: Pull complete 
Digest: sha256:411edce9d0ef63f767d4020af607efafbd97e67026733efe7476730b80010eea
Status: Downloaded newer image for ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.14
 ---> 6feb767ed4cd
Step 2/9 : ARG BUILD_DATE
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 1ae3cc594020
Removing intermediate container 1ae3cc594020
 ---> 5d53c0afdea2
Step 3/9 : ARG VERSION
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in a584e1ef5b75
Removing intermediate container a584e1ef5b75
 ---> e986f0d070a9
Step 4/9 : ARG NGINX_VERSION
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in b2f56010a8b6
Removing intermediate container b2f56010a8b6
 ---> 2f5d9b570ebb
Step 5/9 : LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in f2505c62f69d
Removing intermediate container f2505c62f69d
 ---> b65893605da0
Step 6/9 : LABEL maintainer="aptalca"
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 05a3ee45406f
Removing intermediate container 05a3ee45406f
 ---> e1e16fc180f0
Step 7/9 : ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in b1d4e0a8103d
Removing intermediate container b1d4e0a8103d
 ---> 816700874e20
Step 8/9 : RUN   apk add --no-cache --upgrade     curl &&   if [ -z ${NGINX_VERSION+x} ]; then     NGINX_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp     && awk '/^P:nginx$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://');   fi &&   apk add --no-cache --upgrade     memcached     nginx==${NGINX_VERSION}     nginx-mod-http-brotli==${NGINX_VERSION}     nginx-mod-http-dav-ext==${NGINX_VERSION}     nginx-mod-http-echo==${NGINX_VERSION}     nginx-mod-http-fancyindex==${NGINX_VERSION}     nginx-mod-http-geoip==${NGINX_VERSION}     nginx-mod-http-geoip2==${NGINX_VERSION}     nginx-mod-http-headers-more==${NGINX_VERSION}     nginx-mod-http-image-filter==${NGINX_VERSION}     nginx-mod-http-nchan==${NGINX_VERSION}     nginx-mod-http-perl==${NGINX_VERSION}     nginx-mod-http-redis2==${NGINX_VERSION}     nginx-mod-http-set-misc==${NGINX_VERSION}     nginx-mod-http-upload-progress==${NGINX_VERSION}     nginx-mod-http-xslt-filter==${NGINX_VERSION}     nginx-mod-http-vts==${NGINX_VERSION}     nginx-mod-mail==${NGINX_VERSION}     nginx-mod-rtmp==${NGINX_VERSION}     nginx-mod-stream==${NGINX_VERSION}     nginx-mod-stream-geoip==${NGINX_VERSION}     nginx-mod-stream-geoip2==${NGINX_VERSION}     nginx-vim==${NGINX_VERSION}     php7-bcmath     php7-bz2     php7-ctype     php7-curl     php7-dom     php7-exif     php7-ftp     php7-gd     php7-gmp     php7-iconv     php7-imap     php7-intl     php7-ldap     php7-mcrypt     php7-memcached     php7-mysqli     php7-mysqlnd     php7-opcache     php7-pdo_mysql     php7-pdo_odbc     php7-pdo_pgsql     php7-pdo_sqlite     php7-pear     php7-pecl-apcu     php7-pecl-mailparse     php7-pecl-redis     php7-pgsql     php7-phar     php7-posix     php7-soap     php7-sockets     php7-sodium     php7-sqlite3     php7-tokenizer     php7-xml     php7-xmlreader     php7-xmlrpc     php7-xsl     php7-zip &&   echo "**** configure nginx ****" &&   rm -f /etc/nginx/http.d/default.conf &&   sed -i     's|include /config/nginx/site-confs/\*;|include /config/nginx/site-confs/\*;\n\t#Removed lua. Do not remove this comment|g'     /defaults/nginx.conf
 ---> [Warning] The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 252d8c1206ba
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
(1/1) Installing curl (7.79.1-r1)
Executing busybox-1.33.1-r7.trigger
OK: 61 MiB in 68 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
(1/108) Installing libevent (2.1.12-r2)
(2/108) Installing gdbm (1.19-r0)
(3/108) Installing libsasl (2.1.28-r0)
(4/108) Installing libseccomp (2.5.1-r2)
(5/108) Installing memcached (1.6.9-r0)
Executing memcached-1.6.9-r0.pre-install
(6/108) Installing nginx-mod-http-brotli (1.20.2-r1)
(7/108) Installing nginx-mod-http-dav-ext (1.20.2-r1)
(8/108) Installing nginx-mod-http-echo (1.20.2-r1)
(9/108) Installing nginx-mod-http-fancyindex (1.20.2-r1)
(10/108) Installing geoip (1.6.12-r2)
(11/108) Installing nginx-mod-http-geoip (1.20.2-r1)
(12/108) Installing libmaxminddb (1.5.2-r0)
(13/108) Installing nginx-mod-http-geoip2 (1.20.2-r1)
(14/108) Installing nginx-mod-http-headers-more (1.20.2-r1)
(15/108) Installing libbz2 (1.0.8-r1)
(16/108) Installing libpng (1.6.37-r1)
(17/108) Installing freetype (2.10.4-r3)
(18/108) Installing libjpeg-turbo (2.1.0-r0)
(19/108) Installing libwebp (1.2.0-r2)
(20/108) Installing libgd (2.3.2-r1)
(21/108) Installing nginx-mod-http-image-filter (1.20.2-r1)
(22/108) Installing nginx-mod-http-nchan (1.20.2-r1)
(23/108) Installing perl (5.32.1-r0)
(24/108) Installing perl-error (0.17029-r1)
(25/108) Installing perl-git (2.32.2-r0)
(26/108) Installing git-perl (2.32.2-r0)
(27/108) Installing nginx-mod-http-perl (1.20.2-r1)
(28/108) Installing nginx-mod-http-redis2 (1.20.2-r1)
(29/108) Installing nginx-mod-devel-kit (1.20.2-r1)
(30/108) Installing nginx-mod-http-set-misc (1.20.2-r1)
(31/108) Installing nginx-mod-http-upload-progress (1.20.2-r1)
(32/108) Installing nginx-mod-http-vts (1.20.2-r1)
(33/108) Installing libgpg-error (1.42-r0)
(34/108) Installing libgcrypt (1.9.4-r0)
(35/108) Installing libxslt (1.1.35-r0)
(36/108) Installing nginx-mod-http-xslt-filter (1.20.2-r1)
(37/108) Installing nginx-mod-mail (1.20.2-r1)
(38/108) Installing nginx-mod-rtmp (1.20.2-r1)
(39/108) Installing nginx-mod-stream (1.20.2-r1)
(40/108) Installing nginx-mod-stream-geoip (1.20.2-r1)
(41/108) Installing nginx-mod-stream-geoip2 (1.20.2-r1)
(42/108) Installing nginx-vim (1.20.2-r1)
(43/108) Installing php7-bcmath (7.4.26-r0)
(44/108) Installing php7-bz2 (7.4.26-r0)
(45/108) Installing php7-ctype (7.4.26-r0)
(46/108) Installing php7-curl (7.4.26-r0)
(47/108) Installing php7-dom (7.4.26-r0)
(48/108) Installing php7-exif (7.4.26-r0)
(49/108) Installing php7-ftp (7.4.26-r0)
(50/108) Installing libxau (1.0.9-r0)
(51/108) Installing libmd (1.0.3-r0)
(52/108) Installing libbsd (0.11.3-r0)
(53/108) Installing libxdmcp (1.1.3-r0)
(54/108) Installing libxcb (1.14-r2)
(55/108) Installing libx11 (1.7.2-r0)
(56/108) Installing libxext (1.3.4-r0)
(57/108) Installing libice (1.0.10-r0)
(58/108) Installing libsm (1.2.3-r0)
(59/108) Installing libxt (1.2.1-r0)
(60/108) Installing libxpm (3.5.13-r0)
(61/108) Installing php7-gd (7.4.26-r0)
(62/108) Installing gmp (6.2.1-r1)
(63/108) Installing php7-gmp (7.4.26-r0)
(64/108) Installing php7-iconv (7.4.26-r0)
(65/108) Installing c-client (2007f-r11)
(66/108) Installing php7-imap (7.4.26-r0)
(67/108) Installing libgcc (10.3.1_git20210424-r2)
(68/108) Installing libstdc++ (10.3.1_git20210424-r2)
(69/108) Installing icu-libs (67.1-r2)
(70/108) Installing php7-intl (7.4.26-r0)
(71/108) Installing libldap (2.4.58-r0)
(72/108) Installing php7-ldap (7.4.26-r0)
(73/108) Installing libmcrypt (2.5.8-r9)
(74/108) Installing php7-pecl-mcrypt (1.0.4-r0)
(75/108) Installing php7-pecl-igbinary (3.2.6-r0)
(76/108) Installing libmemcached-libs (1.0.18-r4)
(77/108) Installing php7-pecl-memcached (3.1.5-r2)
(78/108) Installing php7-mysqlnd (7.4.26-r0)
(79/108) Installing php7-mysqli (7.4.26-r0)
(80/108) Installing php7-opcache (7.4.26-r0)
(81/108) Installing php7-pdo (7.4.26-r0)
(82/108) Installing php7-pdo_mysql (7.4.26-r0)
(83/108) Installing unixodbc (2.3.9-r1)
(84/108) Installing php7-pdo_odbc (7.4.26-r0)
(85/108) Installing libpq (13.6-r0)
(86/108) Installing php7-pdo_pgsql (7.4.26-r0)
(87/108) Installing sqlite-libs (3.35.5-r0)
(88/108) Installing php7-pdo_sqlite (7.4.26-r0)
(89/108) Installing php7-pear (7.4.26-r0)
(90/108) Installing php7-pecl-apcu (5.1.21-r0)
(91/108) Installing php7-pecl-mailparse (3.1.1-r1)
(92/108) Installing lz4-libs (1.9.3-r1)
(93/108) Installing zstd-libs (1.4.9-r1)
(94/108) Installing php7-pecl-redis (5.3.4-r0)
(95/108) Installing php7-pgsql (7.4.26-r0)
(96/108) Installing php7-phar (7.4.26-r0)
(97/108) Installing php7-posix (7.4.26-r0)
(98/108) Installing php7-soap (7.4.26-r0)
(99/108) Installing php7-sockets (7.4.26-r0)
(100/108) Installing libsodium (1.0.18-r0)
(101/108) Installing php7-sodium (7.4.26-r0)
(102/108) Installing php7-sqlite3 (7.4.26-r0)
(103/108) Installing php7-tokenizer (7.4.26-r0)
(104/108) Installing php7-xmlreader (7.4.26-r0)
(105/108) Installing php7-xmlrpc (7.4.26-r0)
(106/108) Installing php7-xsl (7.4.26-r0)
(107/108) Installing libzip (1.7.3-r2)
(108/108) Installing php7-zip (7.4.26-r0)
Executing busybox-1.33.1-r7.trigger
OK: 159 MiB in 176 packages
**** configure nginx ****
Removing intermediate container 252d8c1206ba
 ---> a7490caa0be4
Step 9/9 : COPY root/ /
 ---> ca9cc6454dbd
[Warning] One or more build-args [ARCH] were not consumed
Successfully built ca9cc6454dbd
Successfully tagged docker-nginx:aarch64


❯ docker run --rm -t docker-nginx:aarch64 ls /etc
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] 01-envfile: executing... 
[cont-init.d] 01-envfile: exited 0.
[cont-init.d] 02-tamper-check: executing... 
[cont-init.d] 02-tamper-check: exited 0.
[cont-init.d] 10-adduser: executing... 
usermod: no changes

-------------------------------------
          _         ()
         | |  ___   _    __
         | | / __| | |  /  \
         | | \__ \ | | | () |
         |_| |___/ |_|  \__/


Brought to you by linuxserver.io
-------------------------------------

To support LSIO projects visit:
https://www.linuxserver.io/donate/
-------------------------------------
GID/UID
-------------------------------------

User uid:    911
User gid:    911
-------------------------------------

[cont-init.d] 10-adduser: exited 0.
[cont-init.d] 20-config: executing... 
[cont-init.d] 20-config: exited 0.
[cont-init.d] 30-keygen: executing... 
generating self-signed keys in /config/keys, you can replace these with your own keys if required
Generating a RSA private key
.............................................................................................+++++
...............................................+++++
writing new private key to '/config/keys/cert.key'
-----
[cont-init.d] 30-keygen: exited 0.
[cont-init.d] 40-config: executing... 
Starting 2019/12/30, GeoIP2 databases require personal license key to download. Please manually download/update the GeoIP2 db and save as /config/geoip2db/GeoLite2-City.mmdb
[cont-init.d] 40-config: exited 0.
[cont-init.d] 90-custom-folders: executing... 
[cont-init.d] 90-custom-folders: exited 0.
[cont-init.d] 99-custom-files: executing... 
[custom-init] no custom files found exiting...
[cont-init.d] 99-custom-files: exited 0.
[cont-init.d] done.
[services.d] starting services
crond[1517]: crond (busybox 1.33.1) started, log level 5
[services.d] done.
ODBCDataSources       group		      modules	      passwd	   services.d
apk		      group-		      modules-load.d  passwd-	   shadow
ca-certificates       hostname		      motd	      periodic	   shadow-
ca-certificates.conf  hosts		      mtab	      php7	   shells
conf.d		      init.d		      nanorc	      profile	   ssl
cont-finish.d	      inittab		      network	      profile.d    sysctl.conf
cont-init.d	      inputrc		      nginx	      protocols    sysctl.d
crontabs	      libmaxminddb.cron.conf  odbc.ini	      resolv.conf  terminfo
default		      login.defs	      odbcinst.ini    s6	   udhcpd.conf
environment	      logrotate.conf	      openldap	      securetty
fix-attrs.d	      logrotate.d	      opt	      security
fstab		      modprobe.d	      pam.d	      services
[cmd] ls exited 0
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.


❯ docker build -t docker-nginx:armhf --build-arg ARCH=arm32v7/ -f Dockerfile.armhf .
Sending build context to Docker daemon  117.8kB
Step 1/9 : FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm32v7-3.14
arm32v7-3.14: Pulling from linuxserver/baseimage-alpine-nginx
51ae1555a484: Pull complete 
38d0925696ca: Pull complete 
78859b2db3bf: Pull complete 
5c08b8c28904: Pull complete 
98ac91cff1bd: Pull complete 
35755dfc8e8a: Pull complete 
c9077ea2891b: Pull complete 
bd8405c33ea9: Pull complete 
Digest: sha256:80075b76aa6604553dade06bb08638ce4d19f6a5b4591066ab2b45731d74a509
Status: Downloaded newer image for ghcr.io/linuxserver/baseimage-alpine-nginx:arm32v7-3.14
 ---> 4a08d490427b
Step 2/9 : ARG BUILD_DATE
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in d988d24cdf7c
Removing intermediate container d988d24cdf7c
 ---> f741ef61e0a4
Step 3/9 : ARG VERSION
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 0255f85d13a4
Removing intermediate container 0255f85d13a4
 ---> de5467a86b17
Step 4/9 : ARG NGINX_VERSION
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 95085513bfc5
Removing intermediate container 95085513bfc5
 ---> d96ad25347dc
Step 5/9 : LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in cdd56c69c6b1
Removing intermediate container cdd56c69c6b1
 ---> 3538bb0722fb
Step 6/9 : LABEL maintainer="aptalca"
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 62ba8d1f6d5f
Removing intermediate container 62ba8d1f6d5f
 ---> 775ab1381fda
Step 7/9 : ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 8815541324c1
Removing intermediate container 8815541324c1
 ---> 14e9037aff44
Step 8/9 : RUN   apk add --no-cache --upgrade     curl &&   if [ -z ${NGINX_VERSION+x} ]; then     NGINX_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp     && awk '/^P:nginx$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://');   fi &&   apk add --no-cache --upgrade     memcached     nginx==${NGINX_VERSION}     nginx-mod-http-brotli==${NGINX_VERSION}     nginx-mod-http-dav-ext==${NGINX_VERSION}     nginx-mod-http-echo==${NGINX_VERSION}     nginx-mod-http-fancyindex==${NGINX_VERSION}     nginx-mod-http-geoip==${NGINX_VERSION}     nginx-mod-http-geoip2==${NGINX_VERSION}     nginx-mod-http-headers-more==${NGINX_VERSION}     nginx-mod-http-image-filter==${NGINX_VERSION}     nginx-mod-http-nchan==${NGINX_VERSION}     nginx-mod-http-perl==${NGINX_VERSION}     nginx-mod-http-redis2==${NGINX_VERSION}     nginx-mod-http-set-misc==${NGINX_VERSION}     nginx-mod-http-upload-progress==${NGINX_VERSION}     nginx-mod-http-xslt-filter==${NGINX_VERSION}     nginx-mod-http-vts==${NGINX_VERSION}     nginx-mod-mail==${NGINX_VERSION}     nginx-mod-rtmp==${NGINX_VERSION}     nginx-mod-stream==${NGINX_VERSION}     nginx-mod-stream-geoip==${NGINX_VERSION}     nginx-mod-stream-geoip2==${NGINX_VERSION}     nginx-vim==${NGINX_VERSION}     php7-bcmath     php7-bz2     php7-ctype     php7-curl     php7-dom     php7-exif     php7-ftp     php7-gd     php7-gmp     php7-iconv     php7-imap     php7-intl     php7-ldap     php7-mcrypt     php7-memcached     php7-mysqli     php7-mysqlnd     php7-opcache     php7-pdo_mysql     php7-pdo_odbc     php7-pdo_pgsql     php7-pdo_sqlite     php7-pear     php7-pecl-apcu     php7-pecl-mailparse     php7-pecl-redis     php7-pgsql     php7-phar     php7-posix     php7-soap     php7-sockets     php7-sodium     php7-sqlite3     php7-tokenizer     php7-xml     php7-xmlreader     php7-xmlrpc     php7-xsl     php7-zip &&   echo "**** configure nginx ****" &&   rm -f /etc/nginx/http.d/default.conf &&   sed -i     's|include /config/nginx/site-confs/\*;|include /config/nginx/site-confs/\*;\n\t#Removed lua. Do not remove this comment|g'     /defaults/nginx.conf
 ---> [Warning] The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
 ---> Running in 6ba795b152f5
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/main/armv7/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/community/armv7/APKINDEX.tar.gz
(1/1) Installing curl (7.79.1-r1)
Executing busybox-1.33.1-r7.trigger
OK: 47 MiB in 69 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/main/armv7/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.14/community/armv7/APKINDEX.tar.gz
(1/107) Installing libevent (2.1.12-r2)
(2/107) Installing gdbm (1.19-r0)
(3/107) Installing libsasl (2.1.28-r0)
(4/107) Installing libseccomp (2.5.1-r2)
(5/107) Installing memcached (1.6.9-r0)
Executing memcached-1.6.9-r0.pre-install
(6/107) Installing nginx-mod-http-brotli (1.20.2-r1)
(7/107) Installing nginx-mod-http-dav-ext (1.20.2-r1)
(8/107) Installing nginx-mod-http-echo (1.20.2-r1)
(9/107) Installing nginx-mod-http-fancyindex (1.20.2-r1)
(10/107) Installing geoip (1.6.12-r2)
(11/107) Installing nginx-mod-http-geoip (1.20.2-r1)
(12/107) Installing libmaxminddb (1.5.2-r0)
(13/107) Installing nginx-mod-http-geoip2 (1.20.2-r1)
(14/107) Installing nginx-mod-http-headers-more (1.20.2-r1)
(15/107) Installing libbz2 (1.0.8-r1)
(16/107) Installing libpng (1.6.37-r1)
(17/107) Installing freetype (2.10.4-r3)
(18/107) Installing libjpeg-turbo (2.1.0-r0)
(19/107) Installing libwebp (1.2.0-r2)
(20/107) Installing libgd (2.3.2-r1)
(21/107) Installing nginx-mod-http-image-filter (1.20.2-r1)
(22/107) Installing nginx-mod-http-nchan (1.20.2-r1)
(23/107) Installing perl (5.32.1-r0)
(24/107) Installing perl-error (0.17029-r1)
(25/107) Installing perl-git (2.32.2-r0)
(26/107) Installing git-perl (2.32.2-r0)
(27/107) Installing nginx-mod-http-perl (1.20.2-r1)
(28/107) Installing nginx-mod-http-redis2 (1.20.2-r1)
(29/107) Installing nginx-mod-devel-kit (1.20.2-r1)
(30/107) Installing nginx-mod-http-set-misc (1.20.2-r1)
(31/107) Installing nginx-mod-http-upload-progress (1.20.2-r1)
(32/107) Installing nginx-mod-http-vts (1.20.2-r1)
(33/107) Installing libgpg-error (1.42-r0)
(34/107) Installing libgcrypt (1.9.4-r0)
(35/107) Installing libxslt (1.1.35-r0)
(36/107) Installing nginx-mod-http-xslt-filter (1.20.2-r1)
(37/107) Installing nginx-mod-mail (1.20.2-r1)
(38/107) Installing nginx-mod-rtmp (1.20.2-r1)
(39/107) Installing nginx-mod-stream (1.20.2-r1)
(40/107) Installing nginx-mod-stream-geoip (1.20.2-r1)
(41/107) Installing nginx-mod-stream-geoip2 (1.20.2-r1)
(42/107) Installing nginx-vim (1.20.2-r1)
(43/107) Installing php7-bcmath (7.4.26-r0)
(44/107) Installing php7-bz2 (7.4.26-r0)
(45/107) Installing php7-ctype (7.4.26-r0)
(46/107) Installing php7-curl (7.4.26-r0)
(47/107) Installing php7-dom (7.4.26-r0)
(48/107) Installing php7-exif (7.4.26-r0)
(49/107) Installing php7-ftp (7.4.26-r0)
(50/107) Installing libxau (1.0.9-r0)
(51/107) Installing libmd (1.0.3-r0)
(52/107) Installing libbsd (0.11.3-r0)
(53/107) Installing libxdmcp (1.1.3-r0)
(54/107) Installing libxcb (1.14-r2)
(55/107) Installing libx11 (1.7.2-r0)
(56/107) Installing libxext (1.3.4-r0)
(57/107) Installing libice (1.0.10-r0)
(58/107) Installing libsm (1.2.3-r0)
(59/107) Installing libxt (1.2.1-r0)
(60/107) Installing libxpm (3.5.13-r0)
(61/107) Installing php7-gd (7.4.26-r0)
(62/107) Installing gmp (6.2.1-r1)
(63/107) Installing php7-gmp (7.4.26-r0)
(64/107) Installing php7-iconv (7.4.26-r0)
(65/107) Installing c-client (2007f-r11)
(66/107) Installing php7-imap (7.4.26-r0)
(67/107) Installing libstdc++ (10.3.1_git20210424-r2)
(68/107) Installing icu-libs (67.1-r2)
(69/107) Installing php7-intl (7.4.26-r0)
(70/107) Installing libldap (2.4.58-r0)
(71/107) Installing php7-ldap (7.4.26-r0)
(72/107) Installing libmcrypt (2.5.8-r9)
(73/107) Installing php7-pecl-mcrypt (1.0.4-r0)
(74/107) Installing php7-pecl-igbinary (3.2.6-r0)
(75/107) Installing libmemcached-libs (1.0.18-r4)
(76/107) Installing php7-pecl-memcached (3.1.5-r2)
(77/107) Installing php7-mysqlnd (7.4.26-r0)
(78/107) Installing php7-mysqli (7.4.26-r0)
(79/107) Installing php7-opcache (7.4.26-r0)
(80/107) Installing php7-pdo (7.4.26-r0)
(81/107) Installing php7-pdo_mysql (7.4.26-r0)
(82/107) Installing unixodbc (2.3.9-r1)
(83/107) Installing php7-pdo_odbc (7.4.26-r0)
(84/107) Installing libpq (13.6-r0)
(85/107) Installing php7-pdo_pgsql (7.4.26-r0)
(86/107) Installing sqlite-libs (3.35.5-r0)
(87/107) Installing php7-pdo_sqlite (7.4.26-r0)
(88/107) Installing php7-pear (7.4.26-r0)
(89/107) Installing php7-pecl-apcu (5.1.21-r0)
(90/107) Installing php7-pecl-mailparse (3.1.1-r1)
(91/107) Installing lz4-libs (1.9.3-r1)
(92/107) Installing zstd-libs (1.4.9-r1)
(93/107) Installing php7-pecl-redis (5.3.4-r0)
(94/107) Installing php7-pgsql (7.4.26-r0)
(95/107) Installing php7-phar (7.4.26-r0)
(96/107) Installing php7-posix (7.4.26-r0)
(97/107) Installing php7-soap (7.4.26-r0)
(98/107) Installing php7-sockets (7.4.26-r0)
(99/107) Installing libsodium (1.0.18-r0)
(100/107) Installing php7-sodium (7.4.26-r0)
(101/107) Installing php7-sqlite3 (7.4.26-r0)
(102/107) Installing php7-tokenizer (7.4.26-r0)
(103/107) Installing php7-xmlreader (7.4.26-r0)
(104/107) Installing php7-xmlrpc (7.4.26-r0)
(105/107) Installing php7-xsl (7.4.26-r0)
(106/107) Installing libzip (1.7.3-r2)
(107/107) Installing php7-zip (7.4.26-r0)
Executing busybox-1.33.1-r7.trigger
OK: 130 MiB in 176 packages
**** configure nginx ****
Removing intermediate container 6ba795b152f5
 ---> ff17ed3bd944
Step 9/9 : COPY root/ /
 ---> 48e5d40a77db
[Warning] One or more build-args [ARCH] were not consumed
Successfully built 48e5d40a77db
Successfully tagged docker-nginx:armhf


❯ docker run --rm -t docker-nginx:armhf ls /etc
WARNING: The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] 01-envfile: executing... 
[cont-init.d] 01-envfile: exited 0.
[cont-init.d] 02-tamper-check: executing... 
[cont-init.d] 02-tamper-check: exited 0.
[cont-init.d] 10-adduser: executing... 
usermod: no changes

-------------------------------------
          _         ()
         | |  ___   _    __
         | | / __| | |  /  \
         | | \__ \ | | | () |
         |_| |___/ |_|  \__/


Brought to you by linuxserver.io
-------------------------------------

To support LSIO projects visit:
https://www.linuxserver.io/donate/
-------------------------------------
GID/UID
-------------------------------------

User uid:    911
User gid:    911
-------------------------------------

[cont-init.d] 10-adduser: exited 0.
[cont-init.d] 20-config: executing... 
[cont-init.d] 20-config: exited 0.
[cont-init.d] 30-keygen: executing... 
generating self-signed keys in /config/keys, you can replace these with your own keys if required
Generating a RSA private key
..............+++++
...............+++++
writing new private key to '/config/keys/cert.key'
-----
[cont-init.d] 30-keygen: exited 0.
[cont-init.d] 40-config: executing... 
Starting 2019/12/30, GeoIP2 databases require personal license key to download. Please manually download/update the GeoIP2 db and save as /config/geoip2db/GeoLite2-City.mmdb
[cont-init.d] 40-config: exited 0.
[cont-init.d] 90-custom-folders: executing... 
[cont-init.d] 90-custom-folders: exited 0.
[cont-init.d] 99-custom-files: executing... 
[custom-init] no custom files found exiting...
[cont-init.d] 99-custom-files: exited 0.
[cont-init.d] done.
[services.d] starting services
crond[1516]: crond (busybox 1.33.1) started, log level 5
[services.d] done.
ODBCDataSources       group		      modules	      passwd	   services.d
apk		      group-		      modules-load.d  passwd-	   shadow
ca-certificates       hostname		      motd	      periodic	   shadow-
ca-certificates.conf  hosts		      mtab	      php7	   shells
conf.d		      init.d		      nanorc	      profile	   ssl
cont-finish.d	      inittab		      network	      profile.d    sysctl.conf
cont-init.d	      inputrc		      nginx	      protocols    sysctl.d
crontabs	      libmaxminddb.cron.conf  odbc.ini	      resolv.conf  terminfo
default		      login.defs	      odbcinst.ini    s6	   udhcpd.conf
environment	      logrotate.conf	      openldap	      securetty
fix-attrs.d	      logrotate.d	      opt	      security
fstab		      modprobe.d	      pam.d	      services
[cmd] ls exited 0
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
[VTS Pluggin](https://github.com/vozlt/nginx-module-vts)